### PR TITLE
Fix errors and improve logging while updating everything

### DIFF
--- a/src/usr/lib/libre-workspace/portal/unix/unix_scripts/maintenance/update_everything.sh
+++ b/src/usr/lib/libre-workspace/portal/unix/unix_scripts/maintenance/update_everything.sh
@@ -1,42 +1,42 @@
 DATE=`date +"%Y-%m-%d"`
 echo "Starting update at $DATE" >> /var/lib/libre-workspace/portal/history/update-$DATE.log
-echo "Hint: This script runs every day wether some update procedure is enabled or not. If you see 'Cleaning up the system' in the next line, then nothing was updated." >> /var/lib/libre-workspace/portal/history/update-$DATE.log
+echo "Hint: This script runs every day whether some update procedure is enabled or not. If you see 'Cleaning up the system' in the next line, then nothing was updated." >> /var/lib/libre-workspace/portal/history/update-$DATE.log
 
 . /etc/libre-workspace/libre-workspace.conf
 
-if [ "$SYSTEM_AUTOMATIC_UPDATES" == "True" | "$SYSTEM_AUTOMATIC_UPDATES" == "" ]; then
+if [[ "$SYSTEM_AUTOMATIC_UPDATES" == "True" || "$SYSTEM_AUTOMATIC_UPDATES" == "" ]]; then
     echo "Starting system update at $DATE" >> /var/lib/libre-workspace/portal/history/update-$DATE.log 2>&1
     bash do_update.sh >> /var/lib/libre-workspace/portal/history/update-$DATE.log 2>&1
     # Because do_update.sh has its own log file, we append it to our log file
     cat /var/lib/libre-workspace/portal/history/update.log >> /var/lib/libre-workspace/portal/history/update-$DATE.log 2>&1
 fi
 
-if [ "$NEXTCLOUD_AUTOMATIC_UPDATES" == "True" | "$NEXTCLOUD_AUTOMATIC_UPDATES" == "" ]; then
+if [[ "$NEXTCLOUD_AUTOMATIC_UPDATES" == "True" || "$NEXTCLOUD_AUTOMATIC_UPDATES" == "" ]]; then
     echo "Starting nextcloud update at $DATE" >> /var/lib/libre-workspace/portal/history/update-$DATE.log 2>&1
     bash /usr/lib/libre-workspace/modules/nextcloud/update_nextcloud.sh >> /var/lib/libre-workspace/portal/history/update-$DATE.log 2>&1
 fi
 
-if [ "$DESKTOP_AUTOMATIC_UPDATES" == "True" | "$DESKTOP_AUTOMATIC_UPDATES" == "" ]; then
+if [[ "$DESKTOP_AUTOMATIC_UPDATES" == "True" || "$DESKTOP_AUTOMATIC_UPDATES" == "" ]]; then
     echo "Starting cloud desktop update at $DATE" >> /var/lib/libre-workspace/portal/history/update-$DATE.log 2>&1
     bash /usr/lib/libre-workspace/modules/desktop/update_desktop.sh >> /var/lib/libre-workspace/portal/history/update-$DATE.log 2>&1
 fi
 
-if [ "$ONLYOFFICE_AUTOMATIC_UPDATES" == "True" | "$ONLYOFFICE_AUTOMATIC_UPDATES" == "" ]; then
+if [[ "$ONLYOFFICE_AUTOMATIC_UPDATES" == "True" || "$ONLYOFFICE_AUTOMATIC_UPDATES" == "" ]]; then
     echo "Starting onlyoffice update at $DATE" >> /var/lib/libre-workspace/portal/history/update-$DATE.log 2>&1
     bash /usr/lib/libre-workspace/modules/onlyoffice/update_onlyoffice.sh >> /var/lib/libre-workspace/portal/history/update-$DATE.log 2>&1
 fi
 
-if [ "$COLLABORA_AUTOMATIC_UPDATES" == "True" | "$COLLABORA_AUTOMATIC_UPDATES" == "" ]; then
+if [[ "$COLLABORA_AUTOMATIC_UPDATES" == "True" || "$COLLABORA_AUTOMATIC_UPDATES" == "" ]]; then
     echo "Starting collabora update at $DATE" >> /var/lib/libre-workspace/portal/history/update-$DATE.log 2>&1
     bash /usr/lib/libre-workspace/modules/collabora/update_collabora.sh >> /var/lib/libre-workspace/portal/history/update-$DATE.log 2>&1
 fi
 
-if [ "$MATRIX_AUTOMATIC_UPDATES" == "True" | "$MATRIX_AUTOMATIC_UPDATES" == "" ]; then
+if [[ "$MATRIX_AUTOMATIC_UPDATES" == "True" || "$MATRIX_AUTOMATIC_UPDATES" == "" ]]; then
     echo "Starting matrix update at $DATE" >> /var/lib/libre-workspace/portal/history/update-$DATE.log 2>&1
     bash /usr/lib/libre-workspace/modules/matrix/update_matrix.sh >> /var/lib/libre-workspace/portal/history/update-$DATE.log 2>&1
 fi
 
-if [ "$JITSI_AUTOMATIC_UPDATES" == "True" | "$JITSI_AUTOMATIC_UPDATES" == "" ]; then
+if [[ "$JITSI_AUTOMATIC_UPDATES" == "True" || "$JITSI_AUTOMATIC_UPDATES" == "" ]]; then
     echo "Starting jitsi update at $DATE" >> /var/lib/libre-workspace/portal/history/update-$DATE.log 2>&1
     bash /usr/lib/libre-workspace/modules/jitsi/update_jitsi.sh >> /var/lib/libre-workspace/portal/history/update-$DATE.log 2>&1
 fi
@@ -48,12 +48,12 @@ for ADDON in /usr/lib/libre-workspace/modules/*; do
         ADDON_NAME=$(basename $ADDON)
         # Capitalize the addon name and replace "-" with "_" (because of the variable names in /etc/libre-workspace/libre-workspace.conf)
         ADDON_VAR_NAME=$(echo $ADDON_NAME | sed -e 's/\(.*\)/\U\1/' -e 's/-/_/g')
-        if [ "$(eval "echo \$${ADDON_VAR_NAME}_AUTOMATIC_UPDATES")" == "True" | "$(eval "echo \$${ADDON_VAR_NAME}_AUTOMATIC_UPDATES")" == "" ]; then
+        if [[ "$(eval "echo \$${ADDON_VAR_NAME}_AUTOMATIC_UPDATES")" == "True" || "$(eval "echo \$${ADDON_VAR_NAME}_AUTOMATIC_UPDATES")" == "" ]]; then
             echo "Starting update of $ADDON_NAME at $DATE" >> /var/lib/libre-workspace/portal/history/update-$DATE.log 2>&1
             bash /usr/lib/libre-workspace/modules/$ADDON_NAME/update_$ADDON_NAME.sh >> /var/lib/libre-workspace/portal/history/update-$DATE.log 2>&1
         fi
     fi
 done
 
-echo "Cleaning up system..." >> /var/lib/libre-workspace/portal/history/update-$DATE.log
+echo "Cleaning up the system..." >> /var/lib/libre-workspace/portal/history/update-$DATE.log
 bash cleanup.sh >> /var/lib/libre-workspace/portal/history/update-$DATE.log


### PR DESCRIPTION
## Description
Commit b55c83f did break updating while executing the update everything script.

The problem was a non-correct syntax of the bash script "update_everything.sh". That non correct syntax was for example `[ "$SYSTEM_AUTOMATIC_UPDATES" == "True" | "$SYSTEM_AUTOMATIC_UPDATES" == "" ]`. This was changed to `[[ "$SYSTEM_AUTOMATIC_UPDATES" == "True" || "$SYSTEM_AUTOMATIC_UPDATES" == "" ]]` and this was already tested on my own system before creating this PR.

This pull request also fixes a typo and logical errors in the logging of the "update_everything.sh" script.